### PR TITLE
Support tvOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,8 +6,9 @@ import PackageDescription
 let package = Package(
     name: "MulticolorGradient",
     platforms: [
-            .iOS(.v14)
-        ],
+        .iOS(.v14),
+        .tvOS(.v15)
+    ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/Sources/MulticolorGradient/MulticolorGradientViewController.swift
+++ b/Sources/MulticolorGradient/MulticolorGradientViewController.swift
@@ -193,7 +193,7 @@ public class MulticolorGradientViewController: UIViewController, MTKViewDelegate
         computeEncoder?.setBytes(&uniforms, length: MemoryLayout<Uniforms>.size, index: 0)
         computeEncoder?.setTexture(drawable.texture, index: 4)
         
-        if mtkView?.device?.supportsFeatureSet(.iOS_GPUFamily4_v1) ?? false {
+        if mtkView?.device?.supportsFamily(.apple4) ?? false {
             let gridSize = MTLSize(width: drawable.texture.width,
                                    height: drawable.texture.height,
                                    depth: 1)


### PR DESCRIPTION
Replaces deprecated `.supportsFeatureSet()` in favor of `.supportsFamily()` and adds tvOS to list of supported platforms in Package.swift. Can probably add macOS as well but have no need & haven't gotten a chance to test it so won't include it here.

Running well on tvOS on my end!